### PR TITLE
Added functionality of turning nodes in the hierarchy to primitive objects in the Three.js scene

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^7.3.1",
         "@react-three/drei": "^10.7.3",
         "@react-three/fiber": "^9.3.0",
+        "lucide-react": "^0.542.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "three": "^0.179.1",
@@ -3571,6 +3572,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/maath": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^7.3.1",
     "@react-three/drei": "^10.7.3",
     "@react-three/fiber": "^9.3.0",
+    "lucide-react": "^0.542.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "three": "^0.179.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
 
   // State representing the tree. We initialize the root only
   const [root, setRoot] = useState<Node | null>(
-    () => createNode("Root", undefined, undefined, true)
+    () => createNode("Sample Scene", undefined, undefined, true)
   );
   // State representing the currently selected node
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -28,7 +28,7 @@ function App() {
   const justCreatedIdRef = useRef<string | null>(null);
 
   // Handle a newly selected node
-  const onSelectHandler = (id: string) => {
+  const onSelectHandler = (id: string | null) => {
     setSelectedId(id);
   }
 

--- a/frontend/src/components/Hierarchy.tsx
+++ b/frontend/src/components/Hierarchy.tsx
@@ -7,7 +7,7 @@ interface HierarchyProps {
     root: Node;
     justCreatedIdRef: React.RefObject<string | null>;
     selectedId: string | null;
-    onSelect: (id: string) => void;
+    onSelect: (id: string | null) => void;
     onAdd: (
         parentId: string | null,
         name: string,

--- a/frontend/src/components/Inspector.tsx
+++ b/frontend/src/components/Inspector.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import classes from "./Inspector.module.css";
 
 interface InspectorProps {

--- a/frontend/src/components/PrimitivePickerDropdown.module.css
+++ b/frontend/src/components/PrimitivePickerDropdown.module.css
@@ -1,0 +1,51 @@
+.container {
+  position: absolute;
+  top: calc(100% + 6px);   /* appear below the + button */
+  left: 50%;               /* center horizontally under the button */
+  transform: translateX(-50%); /* center anchor */
+  width: 150px;
+  height: 35px;
+  background: var(--chip);
+  color: var(--text);
+  border: 1px solid #1b263b;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  transform-origin: top center;
+  animation: popIn 120ms ease-out both;
+  z-index: 1000;
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: translateX(-50%) scale(0.96); }
+  to   { opacity: 1; transform: translateX(-50%) scale(1); }
+}
+
+.row {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  height: 100%;
+  padding: 0 6px;
+}
+
+.item {
+  position: relative;
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  gap: 6px;
+  user-select: none;
+}
+
+.item:hover {
+  background: var(--chip-hover);
+  border-radius: 6px;
+}
+
+.icon {
+  font-size: 18px;
+  color: #e6efff;
+  opacity: 0.9;
+}

--- a/frontend/src/components/PrimitivePickerDropdown.tsx
+++ b/frontend/src/components/PrimitivePickerDropdown.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import classes from "./PrimitivePickerDropdown.module.css";
+import type { Primitive } from "../scene/types";
+import CropFreeIcon from '@mui/icons-material/CropFree';
+import { Box, Cone, Cylinder, Circle } from 'lucide-react';
+
+interface PrimitivePickerDropdownProps {
+    onPick: (choice: Primitive | null) => void;
+    onDismiss?: () => void;                 // called if user clicks outside / presses Esc
+}
+
+const PrimitivePickerDropdown = (props: PrimitivePickerDropdownProps) => {
+
+    const { onPick, onDismiss } = props;
+
+    // Ref to track outside clicks and focus / position if needed
+    const ref = useRef<HTMLDivElement | null>(null);
+
+    // Close on outside click or escape key
+    useEffect(() => {
+        const onDocDown = (e: MouseEvent) => {
+            if (!ref.current) {
+                return;
+            }
+            if (!ref.current.contains(e.target as Node)) {
+                onDismiss?.();
+            }
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                onDismiss?.();
+            }
+        };
+        document.addEventListener("mousedown", onDocDown);
+        document.addEventListener("keydown", onKey);
+        return () => {
+            document.removeEventListener("mousedown", onDocDown);
+            document.removeEventListener("keydown", onKey);
+        };
+    }, [onDismiss]);
+
+    // Keep clicks inside the popup from triggering the outside-click handler
+    const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+    // Map each primitive
+    const items: { label: string; value: Primitive | null; Icon: React.ElementType }[] = [
+        { label: "Empty", value: null, Icon: CropFreeIcon },
+        { label: "Box", value: "box", Icon: Box },
+        { label: "Cylinder", value: "cylinder", Icon: Cylinder },
+        { label: "Cone", value: "cone", Icon: Cone },
+        { label: "Sphere", value: "sphere", Icon: Circle },
+    ];
+
+    return (
+        <div className={classes.container} ref={ref} onMouseDown={stop} onClick={stop}>
+            <div className={classes.row}>
+                {items.map((item) => (
+                    <div key={item.label} className={classes.item} title={item.label}
+                        onClick={() => { onPick(item.value); onDismiss?.(); }}>
+                        <item.Icon className={classes.icon} />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default PrimitivePickerDropdown;

--- a/frontend/src/components/Scene.tsx
+++ b/frontend/src/components/Scene.tsx
@@ -2,17 +2,22 @@ import { useEffect, useRef } from "react";
 import classes from "./Scene.module.css";
 import * as THREE from 'three';
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { OutlinePass } from 'three/examples/jsm/postprocessing/OutlinePass.js';
+import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
 import type { Node } from "../scene/types";
+import { buildObject, disposeObject } from "../scene/scene";
 
 interface SceneProps {
     root: Node | null;
     selectedId: string | null;
-    onSelect: (id: string) => void;
+    onSelect: (id: string | null) => void;
 }
 
 const Scene = (props: SceneProps) => {
 
-    //const { root, selectedId, onSelect } = props;
+    const { root, selectedId, onSelect } = props;
 
     // Reference to the <div> container in our JSX
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -22,7 +27,17 @@ const Scene = (props: SceneProps) => {
     const sceneRef = useRef<THREE.Scene | null>(null);            
     const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
     const controlsRef = useRef<OrbitControls | null>(null);
-    const frameRef = useRef<number | null>(null);  
+    const frameRef = useRef<number | null>(null);
+    // Holds the content of the built node hierarchy
+    const contentRef = useRef<THREE.Object3D | null>(null);
+    // Post processing refs: help with outline drawing, etc.
+    const composerRef = useRef<EffectComposer | null>(null);
+    const renderPassRef = useRef<RenderPass | null>(null);
+    const primaryOutlinePassRef = useRef<OutlinePass | null>(null);   // selected node
+    const childOutlinePassRef = useRef<OutlinePass | null>(null);     // descendants
+    // Raycasting for selecting objects, etc.
+    const raycasterRef = useRef<THREE.Raycaster>(new THREE.Raycaster());
+    const pointerNdc = useRef(new THREE.Vector2()); // scratch vec2
 
     useEffect(() => {
 
@@ -42,6 +57,8 @@ const Scene = (props: SceneProps) => {
         const h = container.clientHeight || 600;
         renderer.setSize(w, h, false);
         renderer.outputColorSpace = THREE.SRGBColorSpace;
+        renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        renderer.toneMappingExposure = 1.0;
         renderer.shadowMap.enabled = true;
 
         // Append renderer canvas to container
@@ -92,9 +109,119 @@ const Scene = (props: SceneProps) => {
         controls.enablePan = true;
         controlsRef.current = controls;
 
+        // Post-processing pipeline
+        const composer = new EffectComposer(renderer);
+        composer.setSize(w, h)
+        composer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        // Render pass
+        const renderPass = new RenderPass(scene, camera);
+        composer.addPass(renderPass);
+        // Child pass (secondary color)
+        const childPass = new OutlinePass(new THREE.Vector2(w, h), scene, camera);
+        childPass.visibleEdgeColor.set(0x3AA0FF);   // secondary: cool blue
+        childPass.hiddenEdgeColor.set(0x3AA0FF);
+        childPass.edgeStrength = 2.0;
+        childPass.edgeThickness = 0.9;
+        childPass.pulsePeriod = 0;
+        composer.addPass(childPass);
+        // Primary pass (selected node color)
+        const primaryPass = new OutlinePass(new THREE.Vector2(w, h), scene, camera);
+        primaryPass.visibleEdgeColor.set(0xFF8A00); // primary: bright orange
+        primaryPass.hiddenEdgeColor.set(0xFF8A00);
+        primaryPass.edgeStrength = 3.8;
+        primaryPass.edgeThickness = 1.5;
+        primaryPass.pulsePeriod = 0;
+        composer.addPass(primaryPass);
+        // Output pass
+        const outputPass = new OutputPass(); 
+        composer.addPass(outputPass);
+        composerRef.current = composer;
+        renderPassRef.current = renderPass;
+        primaryOutlinePassRef.current = primaryPass;
+        childOutlinePassRef.current = childPass;
+
         // Prevent context menu on right-click dragging
         const preventContext = (e: MouseEvent) => e.preventDefault();
         renderer.domElement.addEventListener("contextmenu", preventContext);
+
+        // Click to select objects on the canvas
+        const handleMouseDown = (e: MouseEvent) => {
+
+            e.stopPropagation();              // don't let the Tree's global "clear selection" run
+
+            if (e.button !== 0) {
+                return;
+            }      // left click only
+
+            const cam = cameraRef.current;
+            const content = contentRef.current;
+            if (!cam || !content) {
+                onSelect(null);
+                return;
+            }
+
+            // Convert to Normalized Device Coordinates
+            const rect = renderer.domElement.getBoundingClientRect();
+            pointerNdc.current.set(
+                ((e.clientX - rect.left) / rect.width) * 2 - 1,
+                -((e.clientY - rect.top) / rect.height) * 2 + 1
+            );
+
+            // Raycast only against our content hierarchy (ignore grid/axes/lights)
+            const ray = raycasterRef.current;
+            ray.setFromCamera(pointerNdc.current, cam);
+            const hits = ray.intersectObject(content, true);
+
+            if (hits.length === 0) {
+                onSelect(null); // clicked empty space
+                return;
+            }
+
+            // Walk up until we find an ancestor with a nodeId
+            let obj: THREE.Object3D | null = hits[0].object;
+            while (obj && !(obj as any).userData?.nodeId) obj = obj.parent;
+            const nodeId = (obj as any)?.userData?.nodeId as string | undefined;
+
+            onSelect(nodeId ?? null);
+        };
+        renderer.domElement.addEventListener("mousedown", handleMouseDown);
+
+        // Handle zooming on a selected object
+        // Here we frame the object based on camera and target bounds, pos, etc.
+        const frameObject = (obj: THREE.Object3D) => {
+            const cam = cameraRef.current!;
+            const controls = controlsRef.current!;
+            const box = new THREE.Box3().setFromObject(obj);
+            const size = new THREE.Vector3();
+            const center = new THREE.Vector3();
+            box.getSize(size);
+            box.getCenter(center);
+
+            const maxSize = Math.max(size.x, size.y, size.z);
+            const fitHeightDistance = maxSize / (2 * Math.tan(THREE.MathUtils.degToRad(cam.fov) / 2));
+            const fitWidthDistance = fitHeightDistance / cam.aspect;
+            const distance = Math.max(fitHeightDistance, fitWidthDistance) * 3.0; // margin
+
+            const dir = new THREE.Vector3()
+                .subVectors(cam.position, controls.target)
+                .normalize();
+
+            cam.position.copy(center).addScaledVector(dir, distance);
+            controls.target.copy(center);
+            cam.updateProjectionMatrix();
+            controls.update();
+        };
+        const handleZoomToNode = (e: Event) => {
+            const id = (e as CustomEvent<{ id: string }>).detail?.id;
+            if (!id || !contentRef.current) return;
+            let target: THREE.Object3D | null = null;
+            contentRef.current.traverse((o) => {
+                if (!target && (o as any).userData?.nodeId === id) target = o;
+            });
+            if (target) frameObject(target);
+        };
+
+        window.addEventListener("scene:zoom-to-node", handleZoomToNode);
 
         // Resizing: instead of resizing the WebGL canvas immediately on every tiny size change
         // (which happens constantly while dragging a gutter), we:
@@ -127,15 +254,14 @@ const Scene = (props: SceneProps) => {
                 rendererRef.current.setSize(desiredW, desiredH, false);
                 cameraRef.current.aspect = desiredW / desiredH;
                 cameraRef.current.updateProjectionMatrix();
+                composerRef.current?.setSize(desiredW, desiredH);
                 needsResize = false; // resize handled for this frame
             }
 
             controlsRef.current?.update();
 
             // Draw the scene
-            if (rendererRef.current && sceneRef.current && cameraRef.current) {
-                rendererRef.current.render(sceneRef.current, cameraRef.current);
-            }
+            composerRef.current?.render();
         };
         tick();
 
@@ -143,25 +269,112 @@ const Scene = (props: SceneProps) => {
         return () => {
             ro.disconnect();
             renderer.domElement.removeEventListener("contextmenu", preventContext);
+            renderer.domElement.removeEventListener("mousedown", handleMouseDown);
+            window.removeEventListener("scene:zoom-to-node", handleZoomToNode);
             if (frameRef.current) {
                 cancelAnimationFrame(frameRef.current);
             }
+
+            // Destroy content
+            if (contentRef.current) {
+                contentRef.current.removeFromParent();
+                disposeObject(contentRef.current);
+                contentRef.current = null;
+            }
+
+            // Destroy post-processing
+            primaryOutlinePassRef.current = null;
+            childOutlinePassRef.current = null;
+            renderPassRef.current = null;
+            composerRef.current?.dispose();
+            composerRef.current = null;
+
             controls.dispose();
             renderer.dispose();
             renderer.domElement.remove();
             rendererRef.current = null;
-            sceneRef.current = null;                                      
+            sceneRef.current = null;
             cameraRef.current = null;
             controlsRef.current = null;
         };
 
     }, []); // run once on mount
 
-    return (
-        <div className={classes.container} ref={containerRef}>
+    // Rebuild scene content whenever the tree changes
+    useEffect(() => {
 
-        </div>
-    )
+        if (!sceneRef.current) {
+            return;
+        }
+
+        // Remove previous content group
+        if (contentRef.current) {
+            contentRef.current.removeFromParent();
+            disposeObject(contentRef.current);
+            contentRef.current = null;
+        }
+
+        if (!root) {
+            return;
+        }
+
+        // Build a fresh hierarchy from the Node tree
+        const built = buildObject(root);
+        sceneRef.current.add(built);
+        contentRef.current = built;
+
+    }, [root]);
+
+    // Draw outline for selected node (x-ray style)
+    useEffect(() => {
+        const primaryPass = primaryOutlinePassRef.current;
+        const childPass = childOutlinePassRef.current;
+        if (!primaryPass || !childPass) {
+            return;
+        }
+
+        primaryPass.selectedObjects = [];
+        childPass.selectedObjects = [];
+
+        if (!selectedId || !contentRef.current) {
+            return;
+        }
+
+        // Find the Object3D corresponding to the selected node (the Group)
+        let groupForNode: THREE.Object3D | null = null;
+        contentRef.current.traverse((o) => {
+            if (!groupForNode && (o as any).userData?.nodeId === selectedId) {
+                groupForNode = o;
+            }
+        });
+        if (!groupForNode) {
+            return;
+        }
+
+        // Collect meshes that belong to the selected node itself (primary),
+        // and meshes that belong to descendant nodes (secondary).
+        const primaryMeshes: THREE.Object3D[] = [];
+        const childMeshes: THREE.Object3D[] = [];
+
+        (groupForNode as THREE.Object3D).traverse((o: THREE.Object3D) => {
+            const mesh = o as THREE.Mesh;
+            if (!mesh.isMesh) {
+                return;
+            }
+            const ownerId = (mesh as any).userData?.nodeId as string | undefined;
+            if (ownerId === selectedId) {
+                primaryMeshes.push(mesh);
+            } else {
+                childMeshes.push(mesh); // descendants (other nodeIds)
+            }
+        });
+
+        // Apply to passes
+        primaryPass.selectedObjects = primaryMeshes;
+        childPass.selectedObjects = childMeshes;
+    }, [selectedId, root]);
+
+    return <div className={classes.container} ref={containerRef} />;
 };
 
 export default Scene;

--- a/frontend/src/components/Tree.tsx
+++ b/frontend/src/components/Tree.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import classes from "./Tree.module.css";
 import type { Node, Transform, Primitive } from "../scene/types";
 import TreeNode from "./TreeNode";
@@ -6,7 +7,7 @@ interface TreeProps {
     root: Node;
     justCreatedIdRef: React.RefObject<string | null>;
     selectedId: string | null;
-    onSelect: (targetId: string) => void;
+    onSelect: (targetId: string | null) => void;
     onAdd: (
         parentId: string | null,
         name: string,
@@ -22,6 +23,13 @@ interface TreeProps {
 const Tree = (props: TreeProps) => {
 
     const { root, justCreatedIdRef, selectedId, onSelect, onAdd, onDelete, onUpdate, onReparent, onReorder } = props;
+
+    // Clear selection when clicking anywhere that isn't stopped (i.e., outside rows/actions/dropdowns)
+    useEffect(() => {
+        const handleDocDown = () => onSelect(null);
+        document.addEventListener("mousedown", handleDocDown);
+        return () => document.removeEventListener("mousedown", handleDocDown);
+    }, [onSelect]);
 
     return (
         <div className={classes.container}>

--- a/frontend/src/components/TreeNode.module.css
+++ b/frontend/src/components/TreeNode.module.css
@@ -23,7 +23,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 16px;
   padding: 3px 0;
   user-select: none;
   cursor: default;          
@@ -79,11 +79,21 @@
 
 /* Inline actions */
 .actions {
-  display: inline-flex;
+  position: relative;       /* ensure dropdown positions to this area */
+  display: flex;
+  align-items: center;
   gap: 6px;
+  overflow: visible;        /* let dropdown escape the row bounds if needed */
 }
 
-.actions button {
+.addWrap {
+  position: relative;       /* dropdown anchors to the + icon wrapper */
+  display: inline-flex;
+  align-items: center;
+}
+
+.icon {
+  position: relative;
   font-size: 12px;
   padding: 2px 6px;
   border-radius: 6px;
@@ -94,7 +104,7 @@
   transition: background 120ms ease, border-color 120ms ease;
 }
 
-.actions button:hover {
+.icon:hover {
   background: var(--chip-hover);
   border-color: var(--line);
 }

--- a/frontend/src/scene/scene.ts
+++ b/frontend/src/scene/scene.ts
@@ -56,6 +56,26 @@ export function buildObject(node: Node): THREE.Object3D {
         group.add(buildObject(child));
     }
 
-    return group;
+  return group;
 }
+
+// Dispose helper to avoid GPU leaks when we replace content
+export function disposeObject(obj: THREE.Object3D) {
+
+  obj.traverse((o) => {
+
+    const mesh = o as THREE.Mesh;
+
+    if (mesh.geometry) {
+      mesh.geometry.dispose();
+    }
+
+    const mat = mesh.material as THREE.Material | THREE.Material[] | undefined;
+
+    if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+    else if (mat) {
+      mat.dispose();
+    }
+  });
+};
 


### PR DESCRIPTION
- Added dropdown `PrimitivePickerDropdown.tsx` for selecting primitive shapes or empty object when creating new nodes
   - Objects are created and rendered in the Three.js scene under their parent's transform
- Added ability to select nodes from inside the scene by left-clicking them
   - Nodes are also de-selected by clicking off of them in the scene / hierarchy
- Added ability to zoom on nodes by double-clicking them in hierarchy
- Refactored editing node names to be a button instead of double-clicking